### PR TITLE
Replaced Swing file chooser by JavaFX one

### DIFF
--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/Main.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/Main.java
@@ -20,10 +20,14 @@ import java.io.File;
 import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import javafx.embed.swing.JFXPanel;
 
 public class Main extends LwjglApplication {
 
 	public static void main(final String[] args) {
+		// This dummy instantiation will initialize JavaFX for us
+		new JFXPanel();
+
 		LwjglApplicationConfiguration cfg = new LwjglApplicationConfiguration();
 
 		cfg.title = "Adventure Composer";

--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/CreateAtlasDialog.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/CreateAtlasDialog.java
@@ -51,7 +51,7 @@ public class CreateAtlasDialog extends EditDialog {
 				"The name of the sprite atlas", true);
 		dir = new FileInputPanel(skin, "Input Image Directory",
 				"Select the output directory with the images to create the Atlas",
-				true);
+				FileInputPanel.DialogType.DIRECTORY);
 
 		filterMin = InputPanelFactory.createInputPanel(skin, "Min Filter",
 				"The filter when the texture is scaled down", FILTERS, true);

--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/CreateProjectDialog.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/CreateProjectDialog.java
@@ -54,10 +54,10 @@ public class CreateProjectDialog extends EditDialog {
 				"The game can use Spine animations, require Spine License to distribute the game. See http://www.esotericsoftware.com for more info.", Param.Type.BOOLEAN, true, "false");
 
 		location = new FileInputPanel(skin, "Location",
-				"Select the folder location for the project", true);
+				"Select the folder location for the project", FileInputPanel.DialogType.DIRECTORY);
 		
 		androidSdk = new FileInputPanel(skin, "Android SDK",
-				"Select the Android SDK folder. If empty, the ANDROID_HOME variable will be used", true);
+				"Select the Android SDK folder. If empty, the ANDROID_HOME variable will be used", FileInputPanel.DialogType.DIRECTORY);
 
 		addInputPanel(projectName);
 		addInputPanel(pkg);

--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/PackageDialog.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/PackageDialog.java
@@ -69,17 +69,17 @@ public class PackageDialog extends EditDialog {
 		super("PACKAGE ADVENTURE", skin);
 
 		arch = InputPanelFactory.createInputPanel(skin, "Architecture", "Select the target Architecture for the game", ARCHS, true);
-		dir = new FileInputPanel(skin, "Output Directory", "Select the output directory to put the package", true);
+		dir = new FileInputPanel(skin, "Output Directory", "Select the output directory to put the package", FileInputPanel.DialogType.DIRECTORY);
 		type = InputPanelFactory.createInputPanel(skin, "Type", "Select the type of the package", TYPES, true);
 		os = InputPanelFactory.createInputPanel(skin, "OS", "Select the OS of the package", OSS, true);
-		linux64JRE = new FileInputPanel(skin, "JRE.Linux64", "Select the 64 bits Linux JRE Location to bundle. Must be a ZIP file", false);
-		linux32JRE = new FileInputPanel(skin, "JRE.Linux32", "Select the 32 bits Linux JRE Location to bundle. Must be a ZIP file", false);
-		winJRE = new FileInputPanel(skin, "JRE.Windows", "Select the Windows JRE Location to bundle. Must be a ZIP file", false);
-		osxJRE = new FileInputPanel(skin, "JRE.OSX", "Select the OSX JRE Location to bundle. Must be a ZIP file", false);
+		linux64JRE = new FileInputPanel(skin, "JRE.Linux64", "Select the 64 bits Linux JRE Location to bundle. Must be a ZIP file", FileInputPanel.DialogType.OPEN_FILE);
+		linux32JRE = new FileInputPanel(skin, "JRE.Linux32", "Select the 32 bits Linux JRE Location to bundle. Must be a ZIP file", FileInputPanel.DialogType.OPEN_FILE);
+		winJRE = new FileInputPanel(skin, "JRE.Windows", "Select the Windows JRE Location to bundle. Must be a ZIP file", FileInputPanel.DialogType.OPEN_FILE);
+		osxJRE = new FileInputPanel(skin, "JRE.OSX", "Select the OSX JRE Location to bundle. Must be a ZIP file", FileInputPanel.DialogType.OPEN_FILE);
 		version = InputPanelFactory.createInputPanel(skin, "Version", "Select the version of the package");
-		icon = new FileInputPanel(skin, "Icon", "The icon for the .exe file", false);
-		androidSDK = new FileInputPanel(skin, "SDK", "Select the Android SDK Location", true);
-		androidKeyStore = new FileInputPanel(skin, "KeyStore", "Select the Key Store Location", false);
+		icon = new FileInputPanel(skin, "Icon", "The icon for the .exe file", FileInputPanel.DialogType.OPEN_FILE);
+		androidSDK = new FileInputPanel(skin, "SDK", "Select the Android SDK Location", FileInputPanel.DialogType.DIRECTORY);
+		androidKeyStore = new FileInputPanel(skin, "KeyStore", "Select the Key Store Location", FileInputPanel.DialogType.OPEN_FILE);
 		androidKeyAlias = InputPanelFactory.createInputPanel(skin, "KeyAlias", "Select the Key Alias Location");
 		androidKeyStorePassword = InputPanelFactory.createInputPanel(skin, "KeyStorePasswd", "Key Store Password", false);
 		androidKeyAliasPassword = InputPanelFactory.createInputPanel(skin, "KeyAliasPasswd", "Key Alias Password", false);

--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/ProjectToolbar.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/ProjectToolbar.java
@@ -21,8 +21,6 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 
-import javax.swing.JFileChooser;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -37,6 +35,8 @@ import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.bladecoder.engineeditor.Ctx;
 import com.bladecoder.engineeditor.model.Project;
 import com.bladecoder.engineeditor.utils.RunProccess;
+import javafx.application.Platform;
+import javafx.stage.DirectoryChooser;
 
 public class ProjectToolbar extends Table {
 	private ImageButton newBtn;
@@ -183,25 +183,32 @@ public class ProjectToolbar extends Table {
 	}
 
 	private void loadProject() {
-		JFileChooser chooser = new JFileChooser(Ctx.project.getProjectDir() != null ? Ctx.project.getProjectDir()
-				: new File("."));
-		chooser.setDialogTitle("Select the project to load");
-		chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-		chooser.setMultiSelectionEnabled(false);
+		Platform.runLater(new Runnable() {
+			@Override
+			public void run() {
+				final DirectoryChooser chooser = new DirectoryChooser();
+				chooser.setTitle("Select the project to load");
+				chooser.setInitialDirectory(Ctx.project.getProjectDir() != null ? Ctx.project.getProjectDir()
+						: new File("."));
 
-		if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
-			try {
-				Ctx.project.saveProject();
-				Ctx.project.loadProject(chooser.getSelectedFile());
-				playBtn.setDisabled(false);
-				packageBtn.setDisabled(false);
-			} catch (Exception ex) {
-				String msg = "Something went wrong while loading the project.\n\n" + ex.getClass().getSimpleName()
-						+ " - " + ex.getMessage();
-				Ctx.msg.show(getStage(), msg, 2);
-				ex.printStackTrace();
+				final File dir = chooser.showDialog(null);
+				if (dir == null) {
+					return;
+				}
+
+				try {
+					Ctx.project.saveProject();
+					Ctx.project.loadProject(dir);
+					playBtn.setDisabled(false);
+					packageBtn.setDisabled(false);
+				} catch (Exception ex) {
+					String msg = "Something went wrong while loading the project.\n\n" + ex.getClass().getSimpleName()
+							+ " - " + ex.getMessage();
+					Ctx.msg.show(getStage(), msg, 2);
+					ex.printStackTrace();
+				}
 			}
-		}
+		});
 	}
 
 	public void exit() {


### PR DESCRIPTION
The existing file choosers have two problems:

1. They block the UI very often (at least on Mac & Linux, but I'm sure this will happen on Windows too), because the're not being run from the EDT. This can easily be solved by using `SwingUtilities.invokeLater` for example.
2. They look awful :D. This can be solved by styling Swing, or by replacing them (the option I took).

JavaFX dialogs are the native ones of the platform (or similar; on Ubuntu you get the normal GTK one instead of the Unity one, but still looks very good) so they look way better IMHO :).