### PR TITLE
Removed `Action.getInfo()` and added `@ActionDescription`

### DIFF
--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/EditActionDialog.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/ui/EditActionDialog.java
@@ -17,6 +17,7 @@ package com.bladecoder.engineeditor.ui;
 
 import java.util.Arrays;
 
+import com.bladecoder.engineeditor.utils.ActionUtils;
 import org.w3c.dom.Element;
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -133,7 +134,7 @@ public class EditActionDialog extends EditElementDialog {
 		}
 
 		if (ac != null) {
-			setInfo(ac.getInfo());
+			setInfo(ActionUtils.getInfo(ac));
 
 			Param[] params = ac.getParams();
 

--- a/adventure-composer/src/main/java/com/bladecoder/engineeditor/utils/ActionUtils.java
+++ b/adventure-composer/src/main/java/com/bladecoder/engineeditor/utils/ActionUtils.java
@@ -1,0 +1,10 @@
+package com.bladecoder.engineeditor.utils;
+
+import com.bladecoder.engine.actions.Action;
+import com.bladecoder.engine.actions.ActionDescription;
+
+public class ActionUtils {
+	public static String getInfo(Action action) {
+		return action.getClass().getAnnotation(ActionDescription.class).value();
+	}
+}

--- a/blade-engine/src/com/bladecoder/engine/actions/Action.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/Action.java
@@ -32,7 +32,9 @@ public interface Action {
 
 	public void setParams(HashMap<String, String> params);
 
-	public String getInfo();
-
+	/**
+	 * @deprecated Need to remove when all Actions are annotated with @ActionDescription & friends
+	 */
+	@Deprecated
 	public Param[] getParams();
 }

--- a/blade-engine/src/com/bladecoder/engine/actions/ActionDescription.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/ActionDescription.java
@@ -1,0 +1,12 @@
+package com.bladecoder.engine.actions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ActionDescription {
+	String value();
+}

--- a/blade-engine/src/com/bladecoder/engine/actions/AnimationAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/AnimationAction.java
@@ -26,21 +26,21 @@ import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Sets the animation for an actor")
 public class AnimationAction implements Action {
-	public static final String INFO = "Sets the animation for an actor";
 	public static final Param[] PARAMS = {
-		new Param("animation", "The Animation to set", Type.ACTOR_ANIMATION, true),	
+		new Param("animation", "The Animation to set", Type.ACTOR_ANIMATION, true),
 		new Param("count", "The times to repeat. -1 to infinity repeat", Type.INTEGER),
 		new Param("wait", "If this param is 'false' the text is showed and the action continues inmediatly", Type.BOOLEAN, true),
 		new Param("animation_type", "The repeat mode", Type.STRING, true, "sprite defined", new String[]{"repeat", "yoyo", "no_repeat", "reverse", "sprite defined"}),
 		new Param("pos", "Puts actor position after setting the animation", Type.VECTOR2, false),
-		new Param("absolute", "Sets the position absolute or relative", Type.BOOLEAN, false)		
-		};		
-	
+		new Param("absolute", "Sets the position absolute or relative", Type.BOOLEAN, false)
+		};
+
 	private static final int NO_POS = 0;
 	private static final int SET_POS_ABSOLUTE = 1;
 	private static final int SET_POS_RELATIVE = 2;
-	
+
 	private String animation;
 	private String actorId;
 	private float posx, posy;
@@ -53,12 +53,12 @@ public class AnimationAction implements Action {
 	public void setParams(HashMap<String, String> params) {
 		actorId = params.get("actor");
 		animation = params.get("animation");
-		
+
 		String a[] = Param.parseString2(animation);
-		
+
 		if(a[0] != null)
 			actorId = a[0];
-		
+
 		animation = a[1];
 
 		if (params.get("pos") != null) {
@@ -67,25 +67,25 @@ public class AnimationAction implements Action {
 			posy = p.y;
 			setPos = SET_POS_ABSOLUTE;
 		}
-		
+
 		if (params.get("absolute") != null) {
 			boolean absolute = Boolean.parseBoolean(params.get("absolute"));
-			
+
 			if(absolute)
 				setPos = SET_POS_ABSOLUTE;
 			else
 				setPos = SET_POS_RELATIVE;
 		}
-		
-		
+
+
 		if(params.get("count") != null) {
 			count = Integer.parseInt(params.get("count"));
 		}
-		
+
 		if(params.get("wait") != null) {
 			wait = Boolean.parseBoolean(params.get("wait"));
 		}
-		
+
 		if(params.get("animation_type") != null) {
 			String repeatStr = params.get("animation_type");
 			if (repeatStr.equalsIgnoreCase("repeat")) {
@@ -95,7 +95,7 @@ public class AnimationAction implements Action {
 			} else if (repeatStr.equalsIgnoreCase("no_repeat")) {
 				repeat = Tween.NO_REPEAT;
 			} else if (repeatStr.equalsIgnoreCase("reverse")) {
-				repeat = Tween.REVERSE;				
+				repeat = Tween.REVERSE;
 			} else {
 				repeat = Tween.FROM_FA;
 			}
@@ -105,25 +105,20 @@ public class AnimationAction implements Action {
 	@Override
 	public boolean run(ActionCallback cb) {
 		EngineLogger.debug(MessageFormat.format("ANIMATION_ACTION: {0}", animation));
-		
+
 		float scale =  EngineAssetManager.getInstance().getScale();
 
 		SpriteActor actor = (SpriteActor) World.getInstance().getCurrentScene().getActor(actorId, true);
-		
+
 		if (setPos == SET_POS_ABSOLUTE)
 			actor.setPosition(posx * scale, posy * scale);
-		else if (setPos == SET_POS_RELATIVE) {		
+		else if (setPos == SET_POS_RELATIVE) {
 			actor.setPosition(actor.getX() + posx * scale, actor.getY() + posy * scale);
 		}
-		
-		actor.startAnimation(animation, repeat, count, wait?cb:null);
-		
-		return wait;
-	}
 
-	@Override
-	public String getInfo() {
-		return INFO;
+		actor.startAnimation(animation, repeat, count, wait?cb:null);
+
+		return wait;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/CameraAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/CameraAction.java
@@ -24,8 +24,8 @@ import com.bladecoder.engine.model.SceneCamera;
 import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Set/Animates the camera position and zoom. Also can stablish the follow character parameter")
 public class CameraAction implements Action {
-	public static final String INFO = "Set/Animates the camera position and zoom. Also can stablish the follow character parameter";
 	public static final Param[] PARAMS = {
 			new Param("pos", "The target position", Type.VECTOR2),
 			new Param("zoom", "The target 'zoom'", Type.FLOAT),
@@ -98,11 +98,6 @@ public class CameraAction implements Action {
 		}
 		
 		return wait;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/CancelVerbAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/CancelVerbAction.java
@@ -30,8 +30,8 @@ import com.bladecoder.engine.util.EngineLogger;
  * 
  * @author rgarcia
  */
+@ActionDescription("Stops the named verb if it is in execution.")
 public class CancelVerbAction implements Action {
-	public static final String INFO = "Stops the named verb if it is in execution.";
 	public static final Param[] PARAMS = {
 			new Param("actor", "The target actor. Empty for the current actor.", Type.ACTOR, false),
 			new Param("verb", "The verb to stop. Empty for the current verb.", Type.STRING, false),
@@ -78,11 +78,6 @@ public class CancelVerbAction implements Action {
 			EngineLogger.error("Cannot find VERB: " + verb + " for ACTOR: " + actorId);
 
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/ChooseAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/ChooseAction.java
@@ -22,13 +22,13 @@ import com.badlogic.gdx.math.MathUtils;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.VerbRunner;
 
+@ActionDescription("Execute only one action inside the Choose/EndChoose block.")
 public class ChooseAction implements Action {
 	private static final String ITERATE = "iterate";
 	private static final String RANDOM = "random";
 	private static final String CYCLE = "cycle";
 
-	public static final String INFO = "Execute only one action inside the Choose/EndChoose block.";
-	public static final Param[] PARAMS = { 
+	public static final Param[] PARAMS = {
 			new Param("chooseCriteria", "The action to execute will be selected following this criteria.",
 				Type.OPTION, true, CYCLE, new String[]{ITERATE, RANDOM, CYCLE}),
 				new Param("endType", "The type for the end action. All control actions must have this attr.", Type.STRING, false, "choose")
@@ -79,11 +79,6 @@ public class ChooseAction implements Action {
 		}
 
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/DropItemAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/DropItemAction.java
@@ -18,10 +18,6 @@ package com.bladecoder.engine.actions;
 import java.text.MessageFormat;
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
-
 import com.badlogic.gdx.math.Vector2;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.assets.EngineAssetManager;
@@ -30,8 +26,8 @@ import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Drops the inventory actor in the scene.")
 public class DropItemAction implements Action {
-	public static final String INFO = "Drops the inventory actor in the scene.";
 	public static final Param[] PARAMS = {
 		new Param("actor", "An actor in the inventory.", Type.STRING, false),
 		new Param("pos", "Position in the scene where de actor is dropped", Type.VECTOR2, false)
@@ -65,11 +61,6 @@ public class DropItemAction implements Action {
 			((SpriteActor)actor).setPosition(pos.x * scale, pos.y * scale);
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/EndAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/EndAction.java
@@ -21,9 +21,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.VerbRunner;
 
+@ActionDescription("Marks the end of a block for a control action")
 public class EndAction implements Action {
-
-	public static final String INFO = "Marks the end of a block for a control action";
 	public static final Param[] PARAMS = { new Param("endType", "The block type", Type.STRING) };
 
 	String type;
@@ -62,11 +61,6 @@ public class EndAction implements Action {
 
 	public String getType() {
 		return type;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/GotoAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/GotoAction.java
@@ -26,8 +26,8 @@ import com.bladecoder.engine.model.CharacterActor;
 import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Walks to the selected position")
 public class GotoAction implements Action {
-	public static final String INFO = "Walks to the selected position";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.ACTOR, false),
 		new Param("pos", "The position to walk to", Type.VECTOR2),
@@ -134,11 +134,6 @@ public class GotoAction implements Action {
 		}
 
 		player.goTo(pf, cb);
-	}		
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/IfAttrAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/IfAttrAction.java
@@ -26,10 +26,9 @@ import com.bladecoder.engine.model.VerbRunner;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Execute the actions inside the If/EndIf if the attribute has the specified value.")
 public class IfAttrAction implements Action {
-
-	public static final String INFO = "Execute the actions inside the If/EndIf if the attribute has the specified value.";
-	public static final Param[] PARAMS = { 
+	public static final Param[] PARAMS = {
 			new Param("actor", "The actor to check its attribute", Type.SCENE_ACTOR),
 			new Param("attr", "The actor attribute", Type.STRING, true, "state", new String[] { "state", "visible"}),
 			new Param("value", "The attribute value", Type.STRING),
@@ -95,11 +94,6 @@ public class IfAttrAction implements Action {
 			ip++;
 
 		v.setIP(ip);		
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/IfPropertyAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/IfPropertyAction.java
@@ -22,9 +22,8 @@ import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.VerbRunner;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Execute the actions inside the If/EndIf if the game propert has the specified value.")
 public class IfPropertyAction implements Action {
-
-	public static final String INFO = "Execute the actions inside the If/EndIf if the game propert has the specified value.";
 	public static final Param[] PARAMS = {
 			new Param("name", "The property name", Type.STRING, true),
 			new Param("value", "The property value", Type.STRING),
@@ -62,11 +61,6 @@ public class IfPropertyAction implements Action {
 			ip++;
 
 		v.setIP(ip);
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/IfSceneAttrAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/IfSceneAttrAction.java
@@ -23,10 +23,9 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.VerbRunner;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Execute the actions inside the If/EndIf if the attribute has the specified value.")
 public class IfSceneAttrAction implements Action {
-
-	public static final String INFO = "Execute the actions inside the If/EndIf if the attribute has the specified value.";
-	public static final Param[] PARAMS = { 
+	public static final Param[] PARAMS = {
 			new Param("scene", "The scene to check its attribute", Type.SCENE),
 			new Param("attr", "The scene attribute", Type.STRING, true, "state", new String[] { "state" }),
 			new Param("value", "The attribute value", Type.STRING),
@@ -67,11 +66,6 @@ public class IfSceneAttrAction implements Action {
 			ip++;
 
 		v.setIP(ip);		
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/LeaveAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/LeaveAction.java
@@ -20,9 +20,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
-
+@ActionDescription("Change the current scene.")
 public class LeaveAction implements Action, ActionCallback {
-	public static final String INFO = "Change the current scene.";
 	public static final Param[] PARAMS = {
 		new Param("scene", "The target scene", Type.SCENE, true),
 	};		
@@ -48,11 +47,6 @@ public class LeaveAction implements Action, ActionCallback {
 		scene = params.get("scene");
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/LoadChapterAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/LoadChapterAction.java
@@ -20,9 +20,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
-
+@ActionDescription("Load the specified Chapter. Scene can be empty to load the default scene.")
 public class LoadChapterAction implements Action {
-	public static final String INFO = "Load the specified Chapter. Scene can be empty to load the default scene.";
 	public static final Param[] PARAMS = {
 		new Param("chapter", "The target chapter", Type.CHAPTER, true),
 		new Param("scene", "The target scene", Type.STRING, false)
@@ -44,11 +43,6 @@ public class LoadChapterAction implements Action {
 		chapter = params.get("chapter");
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/LookAtAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/LookAtAction.java
@@ -29,8 +29,8 @@ import com.bladecoder.engine.model.TextManager;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Shows the text and sets the player to lookat in the selected actor direction")
 public class LookAtAction implements Action {
-	public static final String INFO = "Shows the text and sets the player to lookat in the selected actor direction";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.ACTOR, false),
 		new Param("speech", "The 'soundId' to play if selected", Type.STRING),
@@ -83,11 +83,6 @@ public class LookAtAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/MoveToSceneAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/MoveToSceneAction.java
@@ -24,8 +24,8 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Move the actor to the selected scene")
 public class MoveToSceneAction implements Action {
-	public static final String INFO = "Move the actor to the selected scene";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The selected actor", Type.SCENE_ACTOR),
 		new Param("scene", "The target scene", Type.SCENE)
@@ -76,11 +76,6 @@ public class MoveToSceneAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/MusicAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/MusicAction.java
@@ -17,15 +17,11 @@ package com.bladecoder.engine.actions;
 
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
-
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Play/Stop the music of the current scene")
 public class MusicAction implements Action {
-	public static final String INFO = "Play/Stop the music of the current scene";
 	public static final Param[] PARAMS = { new Param("play",
 			"Play/Stops the music of the scene", Type.BOOLEAN, true), };
 
@@ -47,11 +43,6 @@ public class MusicAction implements Action {
 			World.getInstance().getCurrentScene().stopMusic();
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/PickUpAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/PickUpAction.java
@@ -24,8 +24,8 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Puts the selected actor in the inventory.")
 public class PickUpAction implements Action {
-	public static final String INFO = "Puts the selected actor in the inventory.";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.SCENE_ACTOR, false),
 		new Param("animation", "The animation/sprite to show while in inventory. If empty, the animation will be 'actorid.inventory'", Type.STRING)
@@ -78,12 +78,7 @@ public class PickUpAction implements Action {
 		
 		return false;
 	}
-	
 
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/PositionAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/PositionAction.java
@@ -27,8 +27,8 @@ import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.InterpolationUtils;
 
+@ActionDescription("Sets an actor Position animation")
 public class PositionAction implements Action {
-	public static final String INFO = "Sets an actor Position animation";
 	public static final Param[] PARAMS = {
 			new Param("actor", "The target actor", Type.ACTOR, false),
 			new Param("pos", "The target position", Type.VECTOR2, true),
@@ -119,11 +119,6 @@ public class PositionAction implements Action {
 		}
 
 		return wait;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/PropertyAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/PropertyAction.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Sets a global game property")
 public class PropertyAction implements Action {
-	public static final String INFO = "Sets a global game property";
 	public static final Param[] PARAMS = { new Param("prop", "Property name", Type.STRING, true),
 			new Param("value", "Property value", Type.STRING, true), };
 
@@ -40,11 +40,6 @@ public class PropertyAction implements Action {
 		World.getInstance().setCustomProperty(prop, value);
 
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/RemoveActorAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/RemoveActorAction.java
@@ -23,8 +23,8 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Deletes an actor from the game")
 public class RemoveActorAction implements Action {
-	public static final String INFO = "Deletes an actor from the game";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The actor to remove", Type.SCENE_ACTOR)
 		};		
@@ -69,11 +69,6 @@ public class RemoveActorAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/RemoveInventoryItemAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/RemoveInventoryItemAction.java
@@ -17,15 +17,12 @@ package com.bladecoder.engine.actions;
 
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Remove items from the inventory.")
 public class RemoveInventoryItemAction implements Action {
-	public static final String INFO = "Remove items from the inventory.";
 	public static final Param[] PARAMS = {
 		new Param("id", "The 'actorid' from the inventory item to remove. If empty remove all items.", Type.ACTOR)
 	};		
@@ -49,11 +46,6 @@ public class RemoveInventoryItemAction implements Action {
 		}
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/RepeatAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/RepeatAction.java
@@ -21,9 +21,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.VerbRunner;
 
+@ActionDescription("Repeats the actions inside the Repeat/EndRepeat actions.")
 public class RepeatAction implements Action {
-
-	public static final String INFO = "Repeats the actions inside the Repeat/EndRepeat actions.";
 	public static final Param[] PARAMS = {
 			new Param("repeat", "Repeat the actions the specified times. -1 to infinity",
 					Type.INTEGER, true, "1"),
@@ -55,11 +54,6 @@ public class RepeatAction implements Action {
 		}
 		
 		return false;
-	}
-	
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/RunOnceAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/RunOnceAction.java
@@ -21,9 +21,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.VerbRunner;
 
+@ActionDescription("Execute the actions inside the RunOnce/EndRunOnce only once.")
 public class RunOnceAction implements Action {
-
-	public static final String INFO = "Execute the actions inside the RunOnce/EndRunOnce only once.";
 	public static final Param[] PARAMS = {
 			new Param("endType", "The type for the end action. All control actions must have this attr.", Type.STRING, false, "runonce")};
 
@@ -50,11 +49,6 @@ public class RunOnceAction implements Action {
 		executed=true;
 		
 		return false;
-	}
-	
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/RunVerbAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/RunVerbAction.java
@@ -30,9 +30,8 @@ import com.bladecoder.engine.model.VerbRunner;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Runs an actor verb")
 public class RunVerbAction extends BaseCallbackAction implements VerbRunner {
-
-	public static final String INFO = "Runs an actor verb";
 	public static final Param[] PARAMS = {
 			new Param("actor", "The target actor", Type.ACTOR, false),
 			new Param("verb", "The 'verbId' to run.", Type.STRING, true),
@@ -194,11 +193,6 @@ public class RunVerbAction extends BaseCallbackAction implements VerbRunner {
 		target = json.readValue("target", String.class, jsonData);
 		state = json.readValue("state", String.class, jsonData);
 		super.read(json, jsonData);
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SayAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SayAction.java
@@ -30,8 +30,8 @@ import com.bladecoder.engine.model.Text;
 import com.bladecoder.engine.model.TextManager;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Says a text")
 public class SayAction extends BaseCallbackAction {
-	public static final String INFO = "Says a text";
 	public static final Param[] PARAMS = {
 			new Param("actor", "The target actor", Type.ACTOR, false),
 			new Param("text", "The 'text' to show", Type.SMALL_TEXT),
@@ -216,11 +216,6 @@ public class SayAction extends BaseCallbackAction {
 		pos = json.readValue("pos", Vector2.class, jsonData);
 		quee = json.readValue("quee", Boolean.class, jsonData);
 		super.read(json, jsonData);
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SayDialogAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SayDialogAction.java
@@ -17,8 +17,6 @@ package com.bladecoder.engine.actions;
 
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.BaseCallbackAction;
-import com.bladecoder.engine.actions.Param;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.anim.AnimationDesc;
 import com.badlogic.gdx.graphics.Color;
@@ -31,13 +29,11 @@ import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.Text;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Says the selected option from the current dialog. This action does the next steps:\n" +
+"\n- Sets the player 'talk' animation and say the player text" +
+"\n- Restore the previous player animation and set the target actor 'talk' animation and say the response text" +
+"\n- Restore the target actor animation")
 public class SayDialogAction extends BaseCallbackAction {
-
-	public static final String INFO = 
-			"Says the selected option from the current dialog. This action does the next steps:\n" +
-			"\n- Sets the player 'talk' animation and say the player text" +
-			"\n- Restore the previous player animation and set the target actor 'talk' animation and say the response text" + 
-			"\n- Restore the target actor animation";
 	public static final Param[] PARAMS = {
 			new Param("player_talk_animation", "The player animation for talking instead of the default talk animation.",
 								Type.STRING),
@@ -191,12 +187,7 @@ public class SayDialogAction extends BaseCallbackAction {
 		charTalkAnim = json.readValue("charTalkAnim", String.class, jsonData);
 		super.read(json, jsonData);
 	}
-	
 
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/ScaleAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/ScaleAction.java
@@ -24,8 +24,8 @@ import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.InterpolationUtils;
 
+@ActionDescription("Sets an actor Scale animation")
 public class ScaleAction implements Action {
-	public static final String INFO = "Sets an actor Scale animation";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.ACTOR, false),
 		new Param("scale", "The target scale", Type.FLOAT, true),
@@ -88,11 +88,6 @@ public class ScaleAction implements Action {
 		actor.startScaleAnimation(repeat, count, speed, scale, i, wait?cb:null);
 		
 		return wait;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SetActorAttrAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SetActorAttrAction.java
@@ -18,9 +18,6 @@ package com.bladecoder.engine.actions;
 import java.util.HashMap;
 
 import com.badlogic.gdx.math.Vector2;
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.assets.EngineAssetManager;
 import com.bladecoder.engine.model.BaseActor;
@@ -30,8 +27,8 @@ import com.bladecoder.engine.model.SceneLayer;
 import com.bladecoder.engine.model.SpriteActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Change actor attributes.")
 public class SetActorAttrAction implements Action {
-	public static final String INFO = "Change actor attributes.";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.SCENE_ACTOR, false),
 		new Param("visible", "sets the actor visibility", Type.BOOLEAN), 
@@ -119,11 +116,6 @@ public class SetActorAttrAction implements Action {
 		}
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SetCutmodeAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SetCutmodeAction.java
@@ -17,15 +17,11 @@ package com.bladecoder.engine.actions;
 
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
-
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Set/Unset the cutmode. Also shows/hide the inventory")
 public class SetCutmodeAction implements Action {
-	public static final String INFO = "Set/Unset the cutmode. Also shows/hide the inventory";
 	public static final Param[] PARAMS = {
 		new Param("value", "when 'true' sets the scene in 'cutmode'", Type.BOOLEAN, true, "true")
 		};	
@@ -43,11 +39,6 @@ public class SetCutmodeAction implements Action {
 		World.getInstance().setCutMode(value);
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SetDialogOptionAttrAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SetDialogOptionAttrAction.java
@@ -25,8 +25,8 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Change the selected dialog option properties")
 public class SetDialogOptionAttrAction implements Action {
-	public static final String INFO = "Change the selected dialog option properties";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.SCENE_ACTOR, false),
 		new Param("dialog", "The dialog", Type.STRING, true),	
@@ -104,12 +104,7 @@ public class SetDialogOptionAttrAction implements Action {
 		
 		return false;
 	}
-	
 
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/SetSceneStateAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SetSceneStateAction.java
@@ -21,8 +21,8 @@ import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Sets the scene state")
 public class SetSceneStateAction implements Action {
-	public static final String INFO = "Sets the scene state";
 	public static final Param[] PARAMS = {
 		new Param("scene", "The scene", Type.SCENE),
 		new Param("state", "The scene 'state'", Type.STRING)
@@ -47,11 +47,6 @@ public class SetSceneStateAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/SetStateAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SetStateAction.java
@@ -23,8 +23,8 @@ import com.bladecoder.engine.model.Scene;
 import com.bladecoder.engine.model.World;
 import com.bladecoder.engine.util.EngineLogger;
 
+@ActionDescription("Sets the actor state")
 public class SetStateAction implements Action {
-	public static final String INFO = "Sets the actor state";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.SCENE_ACTOR),
 		new Param("state", "The actor 'state'", Type.STRING)
@@ -70,11 +70,6 @@ public class SetStateAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/ShowInventoryAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/ShowInventoryAction.java
@@ -17,15 +17,11 @@ package com.bladecoder.engine.actions;
 
 import java.util.HashMap;
 
-import com.bladecoder.engine.actions.Action;
-import com.bladecoder.engine.actions.ActionCallback;
-import com.bladecoder.engine.actions.Param;
-
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Shows/Hide the inventory")
 public class ShowInventoryAction implements Action {
-	public static final String INFO = "Shows/Hide the inventory";
 	public static final Param[] PARAMS = {
 		new Param("value", "when 'true' sets the scene in 'cutmode'", Type.BOOLEAN, true, "true")
 		};	
@@ -43,11 +39,6 @@ public class ShowInventoryAction implements Action {
 		World.getInstance().showInventory(value);
 		
 		return false;
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/SoundAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/SoundAction.java
@@ -21,8 +21,8 @@ import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.InteractiveActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Play/Stop a sound")
 public class SoundAction implements Action {
-	public static final String INFO = "Play/Stop a sound";
 	public static final Param[] PARAMS = {
 		new Param("actor", "The target actor", Type.ACTOR, false),
 		new Param("play", "The 'soundId' to play", Type.STRING),
@@ -52,11 +52,6 @@ public class SoundAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/TalktoAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/TalktoAction.java
@@ -21,8 +21,8 @@ import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.CharacterActor;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Sets the dialog mode")
 public class TalktoAction implements Action {
-	public static final String INFO = "Sets the dialog mode";
 	public static final Param[] PARAMS = {
 		new Param("actor",  "The target actor", Type.ACTOR, false),
 		new Param("dialog", "The 'dialogId' to show", Type.STRING, true)
@@ -47,11 +47,6 @@ public class TalktoAction implements Action {
 		return false;
 	}
 
-
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {

--- a/blade-engine/src/com/bladecoder/engine/actions/TransitionAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/TransitionAction.java
@@ -22,8 +22,8 @@ import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.Transition;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Sets a transition effect (FADEIN/FADEOUT)")
 public class TransitionAction implements Action {
-	public static final String INFO = "Sets a transition effect (FADEIN/FADEOUT)";
 	public static final Param[] PARAMS = {
 		new Param("time", "Duration of the transition", Type.FLOAT, true, "1.0"),
 		new Param("color", "The color to fade ('white', 'black' or RRGGBBAA).", Type.STRING, true, "black"),
@@ -70,11 +70,6 @@ public class TransitionAction implements Action {
 		if(params.get("wait") != null) {
 			wait = Boolean.parseBoolean(params.get("wait"));
 		}
-	}
-
-	@Override
-	public String getInfo() {
-		return INFO;
 	}
 
 	@Override

--- a/blade-engine/src/com/bladecoder/engine/actions/WaitAction.java
+++ b/blade-engine/src/com/bladecoder/engine/actions/WaitAction.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import com.bladecoder.engine.actions.Param.Type;
 import com.bladecoder.engine.model.World;
 
+@ActionDescription("Pause the action")
 public class WaitAction implements Action {
-	public static final String INFO = "Pause the action";
 	public static final Param[] PARAMS = {
 		new Param("time", "The time pause in seconds", Type.FLOAT, true, "1.0")
 		};		
@@ -39,12 +39,7 @@ public class WaitAction implements Action {
 	public void setParams(HashMap<String, String> params) {
 		time = Float.parseFloat(params.get("time"));
 	}
-	
 
-	@Override
-	public String getInfo() {
-		return INFO;
-	}
 
 	@Override
 	public Param[] getParams() {


### PR DESCRIPTION
First step towards simplifying `Param`s using annotations. Removed `getInfo()` from `Action` and added an `ActionUtils.getInfo()` that uses the (also introduced) `ActionDescription` annotation.

This can be further improved, if we want to remove those descriptions from memory for performance purposes, although I feel that doing so might be a premature optimization that we'll never need