### PR TITLE
Making Test work with scenes with spaces in ID

### DIFF
--- a/adventure-editor/src/main/java/com/bladecoder/engineeditor/common/RunProccess.java
+++ b/adventure-editor/src/main/java/com/bladecoder/engineeditor/common/RunProccess.java
@@ -48,18 +48,21 @@ public class RunProccess {
 
 	public static boolean runBladeEngine(File prjFolder, String chapter,
 			String scene) throws IOException {
-		String args = ":desktop:run -PappArgs=['-w'";
+		List<String> args = new ArrayList<String>();
+		args.add(":desktop:run");
+		String appArgs = "-PappArgs=['-w'";
 
 		if (chapter != null) {
-			args += ",'-chapter','" + chapter + "'";
-			args += ",'-d'";
+			appArgs += ",'-chapter','" + chapter + "'";
+			appArgs += ",'-d'";
 		}
 
 		if (scene != null) {
-			args += ",'-t','" + scene + "'";
+			appArgs += ",'-t','" + scene + "'";
 		}
 
-		args += "]";
+		appArgs += "]";
+		args.add(appArgs);
 
 		return runGradle(prjFolder, args);
 	}


### PR DESCRIPTION
The test button doesn't work if the scene id has spaces, this patch fixes this problem.